### PR TITLE
replace dotenv with python-dotenv to fix python3 compatibility

### DIFF
--- a/00-Starter-Seed/requirements.txt
+++ b/00-Starter-Seed/requirements.txt
@@ -1,4 +1,4 @@
 flask
-dotenv
+python-dotenv
 PyJWT
 flask-cors

--- a/00-Starter-Seed/server.py
+++ b/00-Starter-Seed/server.py
@@ -1,17 +1,14 @@
 import jwt
-import os
 
+from os import environ as env, path
+from dotenv import load_dotenv
 from functools import wraps
 from flask import Flask, request, jsonify, _app_ctx_stack
-from dotenv import Dotenv
 from flask_cors import cross_origin
 
-try:
-    env = Dotenv('./.env')
-    client_id = env["AUTH0_CLIENT_ID"]
-    client_secret = env["AUTH0_CLIENT_SECRET"]
-except IOError:
-    env = os.environ
+load_dotenv(path.join(path.dirname(__file__), '.env'))
+client_id = env["AUTH0_CLIENT_ID"]
+client_secret = env["AUTH0_CLIENT_SECRET"]
 
 app = Flask(__name__)
 
@@ -92,4 +89,4 @@ def securedPing():
 
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', port=os.environ.get('PORT', 3001))
+    app.run(host='0.0.0.0', port=env.get('PORT', 3001))


### PR DESCRIPTION
In stock virtualenvs running python3, the `dotenv` dependency in `requirements.txt` fails to install (which is actually caused by underlying broken version of `distribute`), which ultimately prevents this project from starting. I've replaced `dotenv` with `python-dotenv` which is more recently maintained and works out-of-the-box with bare virtualenvs for python2 and python3.

There aren't any automated tests in this project, but I've manually tested this with new virtualenvs running python 2.7 and python 3.6.