### PR TITLE
Update python api

### DIFF
--- a/00-Starter-Seed/requirements.txt
+++ b/00-Starter-Seed/requirements.txt
@@ -1,5 +1,5 @@
 flask
 python-dotenv
-python-jose
+python-jose-cryptodome
 flask-cors
 six

--- a/00-Starter-Seed/server.py
+++ b/00-Starter-Seed/server.py
@@ -70,10 +70,11 @@ def requires_scope(required_scope):
     """
     token = get_token_auth_header()
     unverified_claims = jwt.get_unverified_claims(token)
-    token_scopes = unverified_claims["scope"].split()
-    for token_scope in token_scopes:
-        if token_scope == required_scope:
-            return True
+    if unverified_claims.get("scope"):
+        token_scopes = unverified_claims["scope"].split()
+        for token_scope in token_scopes:
+            if token_scope == required_scope:
+                return True
     return False
 
 


### PR DESCRIPTION
Replace `python-jose` by `python-jose-cyptodome`.
Return proper error when access with no scope is sent to `/secured/private/ping` endpoint.
Fixes #21.