### PR TITLE
Correct current CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ defaults: &defaults
           command: | 
             cd $AUTH0_CFG
             mv .env.example .env
-            sed -i 's/{DOMAIN}/'$auth0_domain'/g' .env
-            sed -i 's/{API_IDENTIFIER}/'$api_identifier'/g' .env
+            sed -i 's|{DOMAIN}|'$auth0_domain'|g' .env
+            sed -i 's|{API_IDENTIFIER}|'$api_identifier'|g' .env
       - run:
           name: Background Server
           command: cd $AUTH0_CFG && sh exec.sh


### PR DESCRIPTION
the changes submited correct the syntax problem with the **sed** command when replacing a variable that includes one or multiple slashes.