### PR TITLE
Simplify logic

### DIFF
--- a/00-Starter-Seed/server.py
+++ b/00-Starter-Seed/server.py
@@ -61,12 +61,7 @@ def requires_scope(required_scope):
     """
     token = get_token_auth_header()
     unverified_claims = jwt.get_unverified_claims(token)
-    if unverified_claims.get("scope"):
-        token_scopes = unverified_claims["scope"].split()
-        for token_scope in token_scopes:
-            if token_scope == required_scope:
-                return True
-    return False
+    return required_scope in unverified_claims.get("scope", "").split()
 
 
 def requires_auth(f):

--- a/00-Starter-Seed/server.py
+++ b/00-Starter-Seed/server.py
@@ -43,23 +43,14 @@ def get_token_auth_header():
                         "description":
                             "Authorization header is expected"}, 401)
 
-    parts = auth.split()
-
-    if parts[0].lower() != "bearer":
+    try:
+        bearer, token = auth.split()
+        assert bearer.lower() == "bearer"
+    except (ValueError, AssertionError):
         raise AuthError({"code": "invalid_header",
                         "description":
-                            "Authorization header must start with"
-                            " Bearer"}, 401)
-    elif len(parts) == 1:
-        raise AuthError({"code": "invalid_header",
-                        "description": "Token not found"}, 401)
-    elif len(parts) > 2:
-        raise AuthError({"code": "invalid_header",
-                        "description":
-                            "Authorization header must be"
-                            " Bearer token"}, 401)
+                            "Invalid or missing bearer token"}, 401)
 
-    token = parts[1]
     return token
 
 


### PR DESCRIPTION
Simplify some of the logic here for readability. Note, this reduces some of the verbosity of the `AuthError` message for incorrectly formatted authorization headers, but the existing messages did not seem particularly clear to begin with :)