### PR TITLE
[SDK-3196] Rewrite with Authlib rather than python-jose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,13 +2,37 @@
 machine: &machine-cfg
   image: ubuntu-2004:202107-02
 
-defaults: &defaults
+orbs:
+  python: circleci/python@2.0.3
+
+# Jobs and Workflows
+version: 2.1
+jobs: 
+  checkout:
+    machine:
+      <<: *machine-cfg
+    steps:
+      - checkout
+      - run:
+          name: Clone test script
+          command: git clone -b v0.0.1 --depth 1 https://github.com/auth0-samples/api-quickstarts-tests test
+      - persist_to_workspace:
+          root: ~/ 
+          paths:
+            - project
+            - test
+  integration-tests:
+    machine:
+      <<: *machine-cfg
+    environment:
+      AUTH0_CFG: 00-Starter-Seed
+      SAMPLE_PATH: 00-Starter-Seed
     steps:
       - attach_workspace:
           at: ~/
       - run:
           name: Prepare environment variables
-          command: | 
+          command: |
             cd $AUTH0_CFG
             mv .env.example .env
             sed -i 's|{DOMAIN}|'$auth0_domain'|g' .env
@@ -18,7 +42,7 @@ defaults: &defaults
           command: cd $AUTH0_CFG && sh exec.sh
           background: true
       - run:
-          name: Wait until server is online 
+          name: Wait until server is online
           command: |
             until $(curl --silent --head --output /dev/null --fail http://localhost:3010/api/public); do
                 sleep 5
@@ -42,37 +66,17 @@ defaults: &defaults
       - run:
           name: Execute automated tests
           command: cd test && npm test
-
-# Jobs and Workflows
-version: 2
-jobs: 
-  checkout:
-    machine:
-      <<: *machine-cfg
-    steps:
-      - checkout
-      - run:
-          name: Clone test script
-          command: git clone -b v0.0.1 --depth 1 https://github.com/auth0-samples/api-quickstarts-tests test
-      - persist_to_workspace:
-          root: ~/ 
-          paths:
-            - project
-            - test
-  00-Starter-Seed:
-    machine:
-      <<: *machine-cfg
-    environment:
-      AUTH0_CFG: 00-Starter-Seed
-      SAMPLE_PATH: 00-Starter-Seed
-    <<: *defaults
 workflows:
   version: 2
   API-Tests:
     jobs:
       - checkout:
           context: Quickstart API Tests
-      - 00-Starter-Seed:
+      - python/test:
+          pip-dependency-file: requirements-dev.txt
+          app-dir: ~/project/00-Starter-Seed
+          test-tool: pytest
+      - integration-tests:
           context: Quickstart API Tests
           requires:
             - checkout

--- a/00-Starter-Seed/.gitignore
+++ b/00-Starter-Seed/.gitignore
@@ -1,3 +1,4 @@
 .env
 *.iml
 .idea
+__pycache__

--- a/00-Starter-Seed/README.md
+++ b/00-Starter-Seed/README.md
@@ -8,7 +8,7 @@ Please check our [Quickstart](https://auth0.com/docs/quickstart/backend/python) 
 
 # Running the example
 
-In order to run the example you need to have `python` and `pip` installed.
+In order to run the example you need to have `python 3` and `pip` installed.
 
 You also need to set your Auth0 Domain and the API's audience as environment variables with the following names
 respectively: `AUTH0_DOMAIN` and `API_IDENTIFIER`, which is the audience of your API. You can find an example in the

--- a/00-Starter-Seed/requirements-dev.txt
+++ b/00-Starter-Seed/requirements-dev.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+black==22.1.0
+flake8==4.0.1
+jwcrypto==1.0
+pytest==7.1.0
+pytest-mock==3.7.0

--- a/00-Starter-Seed/requirements.txt
+++ b/00-Starter-Seed/requirements.txt
@@ -1,5 +1,4 @@
-flask
-python-dotenv
-python-jose
-flask-cors
-six
+Flask==2.0.3
+python-dotenv==0.19.2
+Flask-Cors==3.0.10
+Authlib==1.0.0

--- a/00-Starter-Seed/server.py
+++ b/00-Starter-Seed/server.py
@@ -1,17 +1,13 @@
 """Python Flask API Auth0 integration example
 """
 
-from functools import wraps
-import json
 from os import environ as env
-from typing import Dict
-
-from six.moves.urllib.request import urlopen
 
 from dotenv import load_dotenv, find_dotenv
-from flask import Flask, request, jsonify, _request_ctx_stack, Response
+from flask import Flask, jsonify
 from flask_cors import cross_origin
-from jose import jwt
+from authlib.integrations.flask_oauth2 import ResourceProtector
+from validator import Auth0JWTBearerTokenValidator
 
 ENV_FILE = find_dotenv()
 if ENV_FILE:
@@ -19,136 +15,12 @@ if ENV_FILE:
 AUTH0_DOMAIN = env.get("AUTH0_DOMAIN")
 API_IDENTIFIER = env.get("API_IDENTIFIER")
 ALGORITHMS = ["RS256"]
+
+require_oauth = ResourceProtector()
+validator = Auth0JWTBearerTokenValidator(AUTH0_DOMAIN, API_IDENTIFIER)
+require_oauth.register_token_validator(validator)
+
 APP = Flask(__name__)
-
-
-# Format error response and append status code.
-class AuthError(Exception):
-    """
-    An AuthError is raised whenever the authentication failed.
-    """
-    def __init__(self, error: Dict[str, str], status_code: int):
-        super().__init__()
-        self.error = error
-        self.status_code = status_code
-
-
-@APP.errorhandler(AuthError)
-def handle_auth_error(ex: AuthError) -> Response:
-    """
-    serializes the given AuthError as json and sets the response status code accordingly.
-    :param ex: an auth error
-    :return: json serialized ex response
-    """
-    response = jsonify(ex.error)
-    response.status_code = ex.status_code
-    return response
-
-
-def get_token_auth_header() -> str:
-    """Obtains the access token from the Authorization Header
-    """
-    auth = request.headers.get("Authorization", None)
-    if not auth:
-        raise AuthError({"code": "authorization_header_missing",
-                         "description":
-                             "Authorization header is expected"}, 401)
-
-    parts = auth.split()
-
-    if parts[0].lower() != "bearer":
-        raise AuthError({"code": "invalid_header",
-                        "description":
-                            "Authorization header must start with"
-                            " Bearer"}, 401)
-    if len(parts) == 1:
-        raise AuthError({"code": "invalid_header",
-                        "description": "Token not found"}, 401)
-    if len(parts) > 2:
-        raise AuthError({"code": "invalid_header",
-                         "description":
-                             "Authorization header must be"
-                             " Bearer token"}, 401)
-
-    token = parts[1]
-    return token
-
-
-def requires_scope(required_scope: str) -> bool:
-    """Determines if the required scope is present in the access token
-    Args:
-        required_scope (str): The scope required to access the resource
-    """
-    token = get_token_auth_header()
-    unverified_claims = jwt.get_unverified_claims(token)
-    if unverified_claims.get("scope"):
-        token_scopes = unverified_claims["scope"].split()
-        for token_scope in token_scopes:
-            if token_scope == required_scope:
-                return True
-    return False
-
-
-def requires_auth(func):
-    """Determines if the access token is valid
-    """
-    
-    @wraps(func)
-    def decorated(*args, **kwargs):
-        token = get_token_auth_header()
-        jsonurl = urlopen("https://" + AUTH0_DOMAIN + "/.well-known/jwks.json")
-        jwks = json.loads(jsonurl.read())
-        try:
-            unverified_header = jwt.get_unverified_header(token)
-        except jwt.JWTError as jwt_error:
-            raise AuthError({"code": "invalid_header",
-                            "description":
-                                "Invalid header. "
-                                "Use an RS256 signed JWT Access Token"}, 401) from jwt_error
-        if unverified_header["alg"] == "HS256":
-            raise AuthError({"code": "invalid_header",
-                             "description":
-                                 "Invalid header. "
-                                 "Use an RS256 signed JWT Access Token"}, 401)
-        rsa_key = {}
-        for key in jwks["keys"]:
-            if key["kid"] == unverified_header["kid"]:
-                rsa_key = {
-                    "kty": key["kty"],
-                    "kid": key["kid"],
-                    "use": key["use"],
-                    "n": key["n"],
-                    "e": key["e"]
-                }
-        if rsa_key:
-            try:
-                payload = jwt.decode(
-                    token,
-                    rsa_key,
-                    algorithms=ALGORITHMS,
-                    audience=API_IDENTIFIER,
-                    issuer="https://" + AUTH0_DOMAIN + "/"
-                )
-            except jwt.ExpiredSignatureError as expired_sign_error:
-                raise AuthError({"code": "token_expired",
-                                "description": "token is expired"}, 401) from expired_sign_error
-            except jwt.JWTClaimsError as jwt_claims_error:
-                raise AuthError({"code": "invalid_claims",
-                                "description":
-                                    "incorrect claims,"
-                                    " please check the audience and issuer"}, 401) from jwt_claims_error
-            except Exception as exc:
-                raise AuthError({"code": "invalid_header",
-                                "description":
-                                    "Unable to parse authentication"
-                                    " token."}, 401) from exc
-
-            _request_ctx_stack.top.current_user = payload
-            return func(*args, **kwargs)
-        raise AuthError({"code": "invalid_header",
-                         "description": "Unable to find appropriate key"}, 401)
-
-    return decorated
 
 
 # Controllers API
@@ -164,7 +36,7 @@ def public():
 @APP.route("/api/private")
 @cross_origin(headers=["Content-Type", "Authorization"])
 @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])
-@requires_auth
+@require_oauth(None)
 def private():
     """A valid access token is required to access this route
     """
@@ -175,17 +47,12 @@ def private():
 @APP.route("/api/private-scoped")
 @cross_origin(headers=["Content-Type", "Authorization"])
 @cross_origin(headers=["Access-Control-Allow-Origin", "http://localhost:3000"])
-@requires_auth
+@require_oauth("read:messages")
 def private_scoped():
     """A valid access token and an appropriate scope are required to access this route
     """
-    if requires_scope("read:messages"):
-        response = "Hello from a private endpoint! You need to be authenticated and have a scope of read:messages to see this."
-        return jsonify(message=response)
-    raise AuthError({
-        "code": "Unauthorized",
-        "description": "You don't have access to this resource"
-    }, 403)
+    response = "Hello from a private endpoint! You need to be authenticated and have a scope of read:messages to see this."
+    return jsonify(message=response)
 
 
 if __name__ == "__main__":

--- a/00-Starter-Seed/tests/test_validator.py
+++ b/00-Starter-Seed/tests/test_validator.py
@@ -1,0 +1,127 @@
+import json
+import logging
+from datetime import datetime, timedelta
+
+import pytest
+from flask import Flask
+from authlib.integrations.flask_oauth2 import ResourceProtector
+from authlib.jose import JsonWebKey, jwt
+from jwcrypto.jwk import JWK
+from validator import Auth0JWTBearerTokenValidator
+
+AUDIENCE = "my-audience"
+DOMAIN = "my-domain.com"
+
+
+@pytest.fixture()
+def app():
+    require_oauth = ResourceProtector()
+    validator = Auth0JWTBearerTokenValidator(DOMAIN, AUDIENCE)
+    require_oauth.register_token_validator(validator)
+
+    app = Flask(__name__)
+
+    @app.route("/me")
+    @require_oauth(None)
+    def me_api():
+        return {"username": "foo"}
+
+    yield app
+
+
+@pytest.fixture(autouse=True)
+def public_jwk(mocker):
+    key = JWK.generate(
+        kty="RSA", size=2048, alg="RSA-OAEP-256", use="sig", kid="12345"
+    )
+    urlopen = mocker.Mock()
+    urlopen.read.side_effect = [
+        json.dumps(
+            {"keys": [json.loads(key.export_public())]}
+        )
+    ]
+    mocker.patch("validator.urlopen", return_value=urlopen)
+
+    yield JsonWebKey.import_key(json.loads(key.export_private()))
+
+
+def generate_jwt(
+    key,
+    alg="RS256",
+    kid="12345",
+    iss=f"https://{DOMAIN}/",
+    aud=AUDIENCE,
+    exp=datetime.now() + timedelta(days=1),
+):
+    return jwt.encode(
+        {"alg": alg, "kid": kid}, {"iss": iss, "aud": aud, "exp": exp}, key=key
+    ).decode("utf-8")
+
+
+def test_valid_jwt(app, public_jwk):
+    token = generate_jwt(public_jwk)
+    with app.test_client() as client:
+        response = client.get(
+            "/me", headers={"Authorization": f"Bearer {token}"}
+        )
+        assert response.status_code == 200
+
+
+def test_none_alg(app, public_jwk, caplog):
+    caplog.set_level(logging.DEBUG, logger="authlib.oauth2.rfc7523.validator")
+    token = generate_jwt("", alg="none")
+    response = app.test_client().get(
+        "/me", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 401
+    assert response.json["error"] == "invalid_token"
+    assert "bad_signature" in caplog.text
+
+
+def test_wrong_sig(app, public_jwk, caplog):
+    key = JWK.generate(
+        kty="RSA", size=2048, alg="RSA-OAEP-256", use="sig", kid="12345"
+    )
+    caplog.set_level(logging.DEBUG, logger="authlib.oauth2.rfc7523.validator")
+    token = generate_jwt(
+        JsonWebKey.import_key(json.loads(key.export_private()))
+    )
+    response = app.test_client().get(
+        "/me", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 401
+    assert response.json["error"] == "invalid_token"
+    assert "bad_signature" in caplog.text
+
+
+def test_invalid_iss(app, public_jwk, caplog):
+    caplog.set_level(logging.DEBUG, logger="authlib.oauth2.rfc7523.validator")
+    token = generate_jwt(public_jwk, iss="foo")
+    response = app.test_client().get(
+        "/me", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 401
+    assert response.json["error"] == "invalid_token"
+    assert 'invalid_claim' in caplog.text
+
+
+def test_invalid_aud(app, public_jwk, caplog):
+    caplog.set_level(logging.DEBUG, logger="authlib.oauth2.rfc7523.validator")
+    token = generate_jwt(public_jwk, aud="foo")
+    response = app.test_client().get(
+        "/me", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 401
+    assert response.json["error"] == "invalid_token"
+    assert 'invalid_claim' in caplog.text
+
+
+def test_expired_jwt(app, public_jwk, caplog):
+    caplog.set_level(logging.DEBUG, logger="authlib.oauth2.rfc7523.validator")
+    token = generate_jwt(public_jwk, exp=datetime.now() - timedelta(days=1))
+    response = app.test_client().get(
+        "/me", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert response.status_code == 401
+    assert response.json["error"] == "invalid_token"
+    assert "expired_token" in caplog.text

--- a/00-Starter-Seed/validator.py
+++ b/00-Starter-Seed/validator.py
@@ -1,0 +1,20 @@
+import json
+from urllib.request import urlopen
+
+from authlib.oauth2.rfc7523 import JWTBearerTokenValidator
+from authlib.jose.rfc7517.jwk import JsonWebKey
+
+
+class Auth0JWTBearerTokenValidator(JWTBearerTokenValidator):
+
+    def __init__(self, domain, audience):
+        issuer = f"https://{domain}/"
+        jsonurl = urlopen(f"{issuer}.well-known/jwks.json")
+        public_key = JsonWebKey.import_key_set(json.loads(jsonurl.read()))
+        super(Auth0JWTBearerTokenValidator, self).__init__(public_key)
+        self.claims_options = {
+            "exp": {"essential": True},
+            "aud": {"essential": True, "value": audience},
+            "iss": {'essential': True, 'value': issuer}
+        }
+


### PR DESCRIPTION
Authlib 0.x provides middleware that protects Flask APIs with https://datatracker.ietf.org/doc/html/rfc6750 - so we can remove all the code that gets the Bearer Token and Issues spec compliant errors.

When Authlib 1.x is released we can remove `validator.py` as this will include it's own [JWTBearerValidator](https://github.com/lepture/authlib/blob/master/authlib/oauth2/rfc7523/validator.py#L27)